### PR TITLE
changed 'activeresource' to 'active_resource' to fix "The 'activeresource

### DIFF
--- a/basecamp.rb
+++ b/basecamp.rb
@@ -202,6 +202,9 @@ class Basecamp
   end
 
   class Project < Resource
+    def time_entries(options = {})
+      @time_entries ||= TimeEntry.find(:all, :params => options.merge(:project_id => id))
+    end
   end
 
   class Company < Resource


### PR DESCRIPTION
changed 'activeresource' to 'active_resource' to fix "The 'activeresource' library could not be loaded" message when Rails 3 is installed.
