### PR TITLE
Access project from todo_list

### DIFF
--- a/lib/basecamp/resources/todo_list.rb
+++ b/lib/basecamp/resources/todo_list.rb
@@ -1,6 +1,4 @@
 module Basecamp; class TodoList < Basecamp::Resource
-  parent_resources :project
-
   # Returns all lists for a project. If complete is true, only completed lists
   # are returned. If complete is false, only uncompleted lists are returned.
   def self.all(project_id, complete = nil)
@@ -14,7 +12,15 @@ module Basecamp; class TodoList < Basecamp::Resource
     find(:all, :params => { :project_id => project_id, :filter => filter })
   end
 
+  def project
+    @project ||= Project.find(project_id)
+  end
+
   def todo_items(options = {})
     @todo_items ||= TodoItem.find(:all, :params => options.merge(:todo_list_id => id))
+  end
+
+  def prefix_options
+    { :project_id => project_id }
   end
 end; end


### PR DESCRIPTION
This PR is to be able to access project and project_id from todo list:

``` ruby
> Basecamp::TodoList.find(list_id).project_id
=> 1234
> Basecamp::TodoList.find(list_id).project
=> #<Basecamp::Project:0x007fb893d615e8...
```

Ref: https://github.com/anibalcucco/basecamp-wrapper/issues/29

@sprestel can you test this branch in your project and confirm is working?
