### PR TITLE
[34] Use ssl by default

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,11 +47,19 @@ requires your Basecamp site address and your login credentials or API token.
 
   Basecamp.establish_oauth_connection!('yoururl.basecamphq.com', 'oauth_access_token')
 
-=== With a Basecamp account that use SSL (https://yoururl.basecamphq.com)
+=== Using SSL/Non SSL basecamp accounts (https://yoururl.basecamphq.com)
 
-  Basecamp.establish_connection!('yoururl.basecamphq.com', 'APITOKEN', 'X', true)
+Basecamp uses SSL in all accounts so that's the default value here for establish_connection!. This will use https for the connection:
 
-  Basecamp.establish_oauth_connection!('yoururl.basecamphq.com', 'oauth_access_token', true)
+  Basecamp.establish_connection!('yoururl.basecamphq.com', 'APITOKEN', 'X')
+
+  Basecamp.establish_oauth_connection!('yoururl.basecamphq.com', 'oauth_access_token')
+
+But if for some reason your basecamp account doesn't use SSL, you can disable with:
+
+  Basecamp.establish_connection!('yoururl.basecamphq.com', 'APITOKEN', 'X', false)
+
+  Basecamp.establish_oauth_connection!('yoururl.basecamphq.com', 'oauth_access_token', false)
 
 This is the same whether you're accessing using the ActiveResource interface,
 or the legacy interface.

--- a/lib/basecamp/base.rb
+++ b/lib/basecamp/base.rb
@@ -3,7 +3,7 @@ module Basecamp
     attr_accessor :use_xml
     attr_reader :site, :user, :password, :use_ssl, :use_oauth, :access_token
 
-    def establish_connection!(site, user, password, use_ssl = false, use_xml = true)
+    def establish_connection!(site, user, password, use_ssl = true, use_xml = true)
       @site       = site
       @user       = user
       @password   = password
@@ -19,7 +19,7 @@ module Basecamp
       @connection = Connection.new(self)
     end
 
-    def establish_oauth_connection!(site, access_token, use_ssl = false, use_xml = true)
+    def establish_oauth_connection!(site, access_token, use_ssl = true, use_xml = true)
       @site         = site
       @use_ssl      = use_ssl
       @use_xml      = use_xml


### PR DESCRIPTION
Basecamp now uses SSL by default so we should default to true for ```use_ssl``` in ```establish_connection!```.

* Issue: https://github.com/anibalcucco/basecamp-wrapper/issues/34
