### PR TITLE
Fix TodoItem creation by adding todo_list_id as a prefix option

### DIFF
--- a/lib/basecamp/resources/todo_item.rb
+++ b/lib/basecamp/resources/todo_item.rb
@@ -18,4 +18,8 @@ module Basecamp; class TodoItem < Basecamp::Resource
   def uncomplete!
     put(:uncomplete)
   end
+
+  def prefix_options
+    { :todo_list_id => todo_list_id }
+  end
 end; end


### PR DESCRIPTION
In the context of issue https://github.com/anibalcucco/basecamp-wrapper/issues/27 I removed  todo_list as a parent resource in ```TodoItem``` (https://github.com/anibalcucco/basecamp-wrapper/commit/3c5500c1b8450591af3ed8720859235e470b155c) because it was removing ```todo_list_id``` from the list of attributes and that attribute is used in ```TodoItem#todo_list```.

As a consequence of that, creating ```TodoItem``` stopped working:

```
> Basecamp::TodoItem.create(todo_list_id: 123, content: "test")

RuntimeError: The URL or credentials are incorrect, API access is disabled in your Basecamp account, or the todo list with ID '123' does not exist.
```

This PR adds ```todo_list_id``` to ```TodoItem#prefix_options``` to generate the correct URL when we create an item and to still have ```todo_list_id``` as part of the attributes when we load items:

```
# Creating items
> Basecamp::TodoItem.create(todo_list_id: 123, content: "test")
=> #<Basecamp::TodoItem:0x00007f87c50cca48
 @attributes={"todo_list_id"=>123, "content"=>"test", "id"=>"456"},
 @errors=#<ActiveResource::Errors:0x00007f87cd073b48 ...

# Loading items
> todo_items = Basecamp::TodoItem.find(:all, :params => { :todo_list_id => 123 })
> todo_items.first.todo_list_id
=> 123
> todo_items.first.todo_list
=> #<Basecamp::TodoList:0x00007f87c26fd460 ...
```