### PR TITLE
Bump rake and remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,4 @@ gem 'activeresource', '>= 2.3.0'
 group :development do
   gem  'rake'
   gem  'mg',        '>= 0.0.8'
-  gem  'rspec',     '>= 1.3.0'
-  gem  'webmock',   '>= 1.2.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    basecamp (0.0.6)
+    basecamp (0.0.11)
       activeresource (>= 2.3.0)
       oauth2
       xml-simple
@@ -30,10 +30,7 @@ GEM
       faraday (~> 0.4.1)
       multi_json (>= 0.0.4)
     rack (1.2.2)
-    rake (0.8.7)
-    rspec (1.3.0)
-    webmock (1.2.2)
-      addressable (>= 2.1.1)
+    rake (12.3.3)
     xml-simple (1.0.15)
 
 PLATFORMS
@@ -45,6 +42,7 @@ DEPENDENCIES
   mg (>= 0.0.8)
   oauth2
   rake
-  rspec (>= 1.3.0)
-  webmock (>= 1.2.2)
   xml-simple
+
+BUNDLED WITH
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,3 @@ require 'rake'
 
 require 'mg'
 MG.new('basecamp.gemspec')
-
-require 'spec/rake/spectask'
-Spec::Rake::SpecTask.new(:spec) do |spec|
-  spec.libs << '../oa-core/lib' << 'lib' << 'spec'
-  spec.spec_files = FileList['spec/**/*_spec.rb']
-end
-
-task :default => :spec


### PR DESCRIPTION
This is to solve a security vulnerability and to remove unnecessary dependencies with unused gems.